### PR TITLE
Fix possible npe in tests.

### DIFF
--- a/webtest/webtest.go
+++ b/webtest/webtest.go
@@ -206,9 +206,18 @@ func (rt *Route) test(m string, s *httptest.Server, t *testing.T) {
 	}
 
 	for _, r := range rt.routes {
-		req, _ := http.NewRequest("GET", s.URL+r.uri, nil)
+		req, err := http.NewRequest("GET", s.URL+r.uri, nil)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
 		req.Header.Add("Accept", rt.Accept)
-		res, _ := client.Do(req)
+		res, err := client.Do(req)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
 		defer res.Body.Close()
 
 		if res.StatusCode != rt.Response {


### PR DESCRIPTION
Given the errors in Travis I think this should fix the null pointer exception:

```
goroutine 44 [running]:

testing.tRunner.func1(0xc82001ecf0)

	/usr/local/go/src/testing/testing.go:450 +0x171

github.com/GeoNet/web/webtest.(*Route).test(0xc820051ed8, 0xc0acc0, 0x6, 0xc820434200, 0xc82001ecf0)

	/home/travis/gopath/src/github.com/GeoNet/geonet-web/Godeps/_workspace/src/github.com/GeoNet/web/webtest/webtest.go:212 +0x123b
```

Have a look, I'll need to update the Godeps on geonet-web once this is merged.